### PR TITLE
fix(Terraform): wrong PROJECT_ID init

### DIFF
--- a/GSP/Abhi_Firewall_Policy.sh
+++ b/GSP/Abhi_Firewall_Policy.sh
@@ -28,7 +28,7 @@ cat > firewall.tf <<EOF_END
 resource "google_compute_firewall" "allow_ssh" {
   name    = "allow-ssh-from-anywhere"
   network = "default"
-  project = "qwiklabs-gcp-00-5e2401d27ba2"
+  project = "$PROJECT_ID"
 
   allow {
     protocol = "tcp"


### PR DESCRIPTION
This pull request makes a small update to the firewall configuration script, improving its flexibility by replacing a hardcoded project ID with a variable.

* Updated the `project` field in `firewall.tf` to use the `$PROJECT_ID` variable instead of a hardcoded value, allowing the script to work with different projects.